### PR TITLE
Improve Travis CI's scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,13 @@ before_install:
   - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
+
+before_script:
   - make init
+  - docker-compose up -d
 
 script:
-  - make tests
+  - docker-compose run --rm nginx nginx -t
+  - docker-compose run --rm unbound unbound-checkconf
+  - docker-compose run --rm web bundle exec rspec
+  - docker-compose stop


### PR DESCRIPTION
Travis CI上で`make tests`でscriptを実行すると、各々のコマンド
- `docker-compose run --rm nginx nginx -t`
- `docker-compose run --rm unbound unbound-checkconf`
- `docker-compose run --rm web bundle exec rspec`
のresult codeを返さないので、逐次実行するように戻しました。

### Memo

- `script`での実行はエラーが出ても継続する